### PR TITLE
Fix README's run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ https://hub.docker.com/r/cwaffles/openpose
 - CUDA 10.0 or higher on your host, check with `nvidia-smi`
 
 ### Example
-`docker run -v -it --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=0 cwaffles/openpose-python`
+`docker run -it --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=0 cwaffles/openpose-python`
 
 The Openpose repo is in `/openpose`


### PR DESCRIPTION
The `-v` ends up interpreting `-it` as a named volume. This PR removes that.

P.S. great dockerfile -- I found this from https://github.com/CMU-Perceptual-Computing-Lab/openpose/pull/1102. Would recommend this in that PR's place.