### PR TITLE
Fix: Update CUDA Base Image from 11.4.0 to 11.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/cwaffles/openpose
-FROM nvidia/cuda:11.4.0-cudnn8-devel-ubuntu18.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu18.04
 
 #get deps
 RUN apt-get update && \


### PR DESCRIPTION
### Description
This pull request addresses an issue with the Docker build process failing due to the missing CUDA base image version 11.4.0. The error encountered is shown below:

```
ERROR [internal] load metadata for docker.io/nvidia/cuda:11.4.0-cudnn8-devel-ubuntu18.04
docker.io/nvidia/cuda:11.4.0-cudnn8-devel-ubuntu18.04: not found
```

### Reason for the Change
Issue Resolution: The specified CUDA base image 11.4.0 is unavailable in the Docker registry, causing build failures.
Compatibility: CUDA 11.8.0 is compatible with the current setup and does not introduce any breaking changes to the application.

### Testing Performed
Docker Build:
- Executed the following command to build the Docker image:
```
docker build -t openpose .
```
- Outcome: The build completed successfully without errors, confirming that the new base image is available and compatible.